### PR TITLE
test: evaluateSpectrum と pitchDetection のユニットテスト追加

### DIFF
--- a/__tests__/lib/audio_analysis/justAnalyze.test.ts
+++ b/__tests__/lib/audio_analysis/justAnalyze.test.ts
@@ -1,0 +1,375 @@
+import { evaluateSpectrum } from "@/lib/audio_analysis/justAnalyze";
+import type { Pitch } from "@/lib/types";
+
+/**
+ * テスト用ヘルパー: 等間隔の周波数ビン配列を生成
+ * AnalyserNode の周波数ビンを模擬する
+ */
+function makeFreqBins(sampleRate: number, fftSize: number): number[] {
+  const binCount = fftSize / 2;
+  const step = sampleRate / fftSize;
+  return Array.from({ length: binCount }, (_, i) => i * step);
+}
+
+/**
+ * テスト用ヘルパー: 指定周波数にガウシアンピークを持つスペクトルを生成（dB単位）
+ */
+function makeSpectrum(
+  freq: number[],
+  peakFreq: number,
+  peakDb: number = 0,
+  floorDb: number = -120
+): Float32Array {
+  const spec = new Float32Array(freq.length);
+  for (let i = 0; i < freq.length; i++) {
+    const distance = Math.abs(freq[i] - peakFreq);
+    const step = freq.length > 1 ? freq[1] - freq[0] : 1;
+    // ガウシアン形状のピーク
+    const attenuation = -((distance / step) ** 2) * 3;
+    spec[i] = Math.max(floorDb, peakDb + attenuation);
+  }
+  return spec;
+}
+
+describe("evaluateSpectrum", () => {
+  const A4_FREQ = 440;
+  const EVAL_RANGE_CENTS = 50;
+  const EVAL_THRESHOLD = -100;
+  const SAMPLE_RATE = 44100;
+  const FFT_SIZE = 4096;
+
+  const freq = makeFreqBins(SAMPLE_RATE, FFT_SIZE);
+  // 周波数分解能 ≈ 10.77Hz
+
+  const cMajorPitchList: Pitch[] = [
+    { pitchName: "C", octaveNum: 4, isRoot: true },
+    { pitchName: "E", octaveNum: 4, isRoot: false },
+    { pitchName: "G", octaveNum: 4, isRoot: false },
+  ];
+
+  describe("基本動作", () => {
+    it("純正律のピッチに一致するスペクトルではdeviation≈0を返す", () => {
+      // C4の純正律周波数 = 440 * 2^(-9/12) ≈ 261.63Hz
+      const c4Freq = A4_FREQ * Math.pow(2, -9 / 12);
+      const spec = makeSpectrum(freq, c4Freq, 0);
+
+      const pitchList: Pitch[] = [
+        { pitchName: "C", octaveNum: 4, isRoot: true },
+      ];
+
+      const result = evaluateSpectrum(
+        spec,
+        freq,
+        pitchList,
+        EVAL_RANGE_CENTS,
+        A4_FREQ,
+        EVAL_THRESHOLD
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].deviation).not.toBeNull();
+      // 周波数分解能の制約で完全な0にはならないが、近い値
+      expect(Math.abs(result[0].deviation!)).toBeLessThan(0.3);
+      expect(result[0].centDeviation).not.toBeNull();
+    });
+
+    it("複数音（Cメジャーコード）を同時に評価できる", () => {
+      const c4Freq = A4_FREQ * Math.pow(2, -9 / 12);
+      const e4JustFreq = c4Freq * 5 / 4; // 純正律の長3度
+      const g4JustFreq = c4Freq * 3 / 2; // 純正律の完全5度
+
+      // 3つのピークを持つスペクトルを合成
+      const spec = new Float32Array(freq.length).fill(-120);
+      for (const peakF of [c4Freq, e4JustFreq, g4JustFreq]) {
+        const single = makeSpectrum(freq, peakF, 0);
+        for (let i = 0; i < spec.length; i++) {
+          // dBの加算（線形変換して加算し直す）
+          spec[i] = Math.max(spec[i], single[i]);
+        }
+      }
+
+      const result = evaluateSpectrum(
+        spec,
+        freq,
+        cMajorPitchList,
+        EVAL_RANGE_CENTS,
+        A4_FREQ,
+        EVAL_THRESHOLD
+      );
+
+      expect(result).toHaveLength(3);
+      result.forEach((r) => {
+        expect(r.deviation).not.toBeNull();
+        expect(r.centDeviation).not.toBeNull();
+      });
+    });
+
+    it("各結果のdeviation値は-1.0〜1.0の範囲に収まる", () => {
+      const c4Freq = A4_FREQ * Math.pow(2, -9 / 12);
+      // 意図的にずらしたピークを作る
+      const shiftedFreq = c4Freq * Math.pow(2, 40 / 1200); // +40セント
+      const spec = makeSpectrum(freq, shiftedFreq, 0);
+
+      const pitchList: Pitch[] = [
+        { pitchName: "C", octaveNum: 4, isRoot: true },
+      ];
+
+      const result = evaluateSpectrum(
+        spec,
+        freq,
+        pitchList,
+        EVAL_RANGE_CENTS,
+        A4_FREQ,
+        EVAL_THRESHOLD
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].deviation).not.toBeNull();
+      expect(result[0].deviation!).toBeGreaterThanOrEqual(-1);
+      expect(result[0].deviation!).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe("セント偏差の方向", () => {
+    it("ピッチが高い方にずれている場合、centDeviationは正", () => {
+      const c4Freq = A4_FREQ * Math.pow(2, -9 / 12);
+      const sharpFreq = c4Freq * Math.pow(2, 30 / 1200); // +30セント
+      const spec = makeSpectrum(freq, sharpFreq, 0);
+
+      const pitchList: Pitch[] = [
+        { pitchName: "C", octaveNum: 4, isRoot: true },
+      ];
+
+      const result = evaluateSpectrum(
+        spec,
+        freq,
+        pitchList,
+        EVAL_RANGE_CENTS,
+        A4_FREQ,
+        EVAL_THRESHOLD
+      );
+
+      expect(result[0].centDeviation).not.toBeNull();
+      expect(result[0].centDeviation!).toBeGreaterThan(0);
+      expect(result[0].deviation!).toBeGreaterThan(0);
+    });
+
+    it("ピッチが低い方にずれている場合、centDeviationは負", () => {
+      const c4Freq = A4_FREQ * Math.pow(2, -9 / 12);
+      const flatFreq = c4Freq * Math.pow(2, -30 / 1200); // -30セント
+      const spec = makeSpectrum(freq, flatFreq, 0);
+
+      const pitchList: Pitch[] = [
+        { pitchName: "C", octaveNum: 4, isRoot: true },
+      ];
+
+      const result = evaluateSpectrum(
+        spec,
+        freq,
+        pitchList,
+        EVAL_RANGE_CENTS,
+        A4_FREQ,
+        EVAL_THRESHOLD
+      );
+
+      expect(result[0].centDeviation).not.toBeNull();
+      expect(result[0].centDeviation!).toBeLessThan(0);
+      expect(result[0].deviation!).toBeLessThan(0);
+    });
+  });
+
+  describe("閾値処理", () => {
+    it("スペクトルが閾値以下の場合はnullを返す", () => {
+      // 非常に弱いスペクトル
+      const spec = new Float32Array(freq.length).fill(-150);
+
+      const pitchList: Pitch[] = [
+        { pitchName: "C", octaveNum: 4, isRoot: true },
+      ];
+
+      const result = evaluateSpectrum(
+        spec,
+        freq,
+        pitchList,
+        EVAL_RANGE_CENTS,
+        A4_FREQ,
+        EVAL_THRESHOLD
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].deviation).toBeNull();
+      expect(result[0].centDeviation).toBeNull();
+    });
+
+    it("閾値をちょうど超えるスペクトルは検出される", () => {
+      const c4Freq = A4_FREQ * Math.pow(2, -9 / 12);
+      const spec = makeSpectrum(freq, c4Freq, EVAL_THRESHOLD + 5, -150);
+
+      const pitchList: Pitch[] = [
+        { pitchName: "C", octaveNum: 4, isRoot: true },
+      ];
+
+      const result = evaluateSpectrum(
+        spec,
+        freq,
+        pitchList,
+        EVAL_RANGE_CENTS,
+        A4_FREQ,
+        EVAL_THRESHOLD
+      );
+
+      expect(result[0].deviation).not.toBeNull();
+    });
+  });
+
+  describe("エッジケース", () => {
+    it("根音が設定されていない場合は空配列を返す", () => {
+      const spec = new Float32Array(freq.length).fill(0);
+
+      const pitchList: Pitch[] = [
+        { pitchName: "C", octaveNum: 4, isRoot: false },
+      ];
+
+      const result = evaluateSpectrum(
+        spec,
+        freq,
+        pitchList,
+        EVAL_RANGE_CENTS,
+        A4_FREQ,
+        EVAL_THRESHOLD
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("enabled=falseの音はdeviation=nullを返す", () => {
+      const c4Freq = A4_FREQ * Math.pow(2, -9 / 12);
+      const spec = makeSpectrum(freq, c4Freq, 0);
+
+      const pitchList: Pitch[] = [
+        { pitchName: "C", octaveNum: 4, isRoot: true, enabled: true },
+        { pitchName: "E", octaveNum: 4, isRoot: false, enabled: false },
+      ];
+
+      const result = evaluateSpectrum(
+        spec,
+        freq,
+        pitchList,
+        EVAL_RANGE_CENTS,
+        A4_FREQ,
+        EVAL_THRESHOLD
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].deviation).not.toBeNull();
+      expect(result[1].deviation).toBeNull();
+      expect(result[1].centDeviation).toBeNull();
+    });
+
+    it("空のピッチリストでは空配列を返す", () => {
+      const spec = new Float32Array(freq.length).fill(0);
+
+      const result = evaluateSpectrum(
+        spec,
+        freq,
+        [],
+        EVAL_RANGE_CENTS,
+        A4_FREQ,
+        EVAL_THRESHOLD
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("evalRangeCentsが0の場合でもクラッシュしない", () => {
+      const c4Freq = A4_FREQ * Math.pow(2, -9 / 12);
+      const spec = makeSpectrum(freq, c4Freq, 0);
+
+      const pitchList: Pitch[] = [
+        { pitchName: "C", octaveNum: 4, isRoot: true },
+      ];
+
+      expect(() => {
+        evaluateSpectrum(
+          spec,
+          freq,
+          pitchList,
+          0, // evalRangeCents = 0
+          A4_FREQ,
+          EVAL_THRESHOLD
+        );
+      }).not.toThrow();
+    });
+  });
+
+  describe("デバッグ情報", () => {
+    it("includeDebug=trueの場合、debugフィールドが含まれる", () => {
+      const c4Freq = A4_FREQ * Math.pow(2, -9 / 12);
+      const spec = makeSpectrum(freq, c4Freq, 0);
+
+      const pitchList: Pitch[] = [
+        { pitchName: "C", octaveNum: 4, isRoot: true },
+      ];
+
+      const result = evaluateSpectrum(
+        spec,
+        freq,
+        pitchList,
+        EVAL_RANGE_CENTS,
+        A4_FREQ,
+        EVAL_THRESHOLD,
+        { includeDebug: true }
+      );
+
+      expect(result[0].debug).toBeDefined();
+      expect(result[0].debug!.estFreqHz).toBeGreaterThan(0);
+      expect(result[0].debug!.range).toBeDefined();
+      expect(result[0].debug!.peak).toBeDefined();
+    });
+
+    it("includeDebug=falseの場合、debugフィールドはない", () => {
+      const c4Freq = A4_FREQ * Math.pow(2, -9 / 12);
+      const spec = makeSpectrum(freq, c4Freq, 0);
+
+      const pitchList: Pitch[] = [
+        { pitchName: "C", octaveNum: 4, isRoot: true },
+      ];
+
+      const result = evaluateSpectrum(
+        spec,
+        freq,
+        pitchList,
+        EVAL_RANGE_CENTS,
+        A4_FREQ,
+        EVAL_THRESHOLD,
+        { includeDebug: false }
+      );
+
+      expect(result[0].debug).toBeUndefined();
+    });
+  });
+
+  describe("異なるA4基準周波数", () => {
+    it("A4=442Hzでも正しく動作する", () => {
+      const customA4 = 442;
+      const a4Spec = makeSpectrum(freq, customA4, 0);
+
+      const pitchList: Pitch[] = [
+        { pitchName: "A", octaveNum: 4, isRoot: true },
+      ];
+
+      const result = evaluateSpectrum(
+        a4Spec,
+        freq,
+        pitchList,
+        EVAL_RANGE_CENTS,
+        customA4,
+        EVAL_THRESHOLD
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].deviation).not.toBeNull();
+      expect(Math.abs(result[0].centDeviation!)).toBeLessThan(15);
+    });
+  });
+});

--- a/__tests__/lib/audio_analysis/pitchDetection.test.ts
+++ b/__tests__/lib/audio_analysis/pitchDetection.test.ts
@@ -1,0 +1,223 @@
+import {
+  frequencyToNote,
+  detectPitch,
+  aggregatePitchResults,
+} from "@/lib/audio_analysis/pitchDetection";
+import type { PitchCandidate } from "@/lib/audio_analysis/pitchDetection";
+
+/**
+ * テスト用ヘルパー: 指定周波数の正弦波を生成
+ */
+function generateSineWave(
+  frequency: number,
+  sampleRate: number,
+  length: number,
+  amplitude: number = 0.5
+): Float32Array {
+  const buffer = new Float32Array(length);
+  for (let i = 0; i < length; i++) {
+    buffer[i] = amplitude * Math.sin(2 * Math.PI * frequency * i / sampleRate);
+  }
+  return buffer;
+}
+
+describe("frequencyToNote", () => {
+  it("440HzをA4に変換する", () => {
+    const result = frequencyToNote(440, 440);
+    expect(result.pitchName).toBe("A");
+    expect(result.octaveNum).toBe(4);
+  });
+
+  it("261.63Hz付近をC4に変換する", () => {
+    const c4Freq = 440 * Math.pow(2, -9 / 12); // ≈261.63Hz
+    const result = frequencyToNote(c4Freq, 440);
+    expect(result.pitchName).toBe("C");
+    expect(result.octaveNum).toBe(4);
+  });
+
+  it("880HzをA5に変換する", () => {
+    const result = frequencyToNote(880, 440);
+    expect(result.pitchName).toBe("A");
+    expect(result.octaveNum).toBe(5);
+  });
+
+  it("220HzをA3に変換する", () => {
+    const result = frequencyToNote(220, 440);
+    expect(result.pitchName).toBe("A");
+    expect(result.octaveNum).toBe(3);
+  });
+
+  it("A4=442Hz基準でも正しく変換する", () => {
+    const result = frequencyToNote(442, 442);
+    expect(result.pitchName).toBe("A");
+    expect(result.octaveNum).toBe(4);
+  });
+
+  it("各音名を正しく変換する", () => {
+    const noteFreqs: [number, string][] = [
+      [261.63, "C"],
+      [293.66, "D"],
+      [329.63, "E"],
+      [349.23, "F"],
+      [392.00, "G"],
+      [440.00, "A"],
+      [493.88, "B"],
+    ];
+
+    for (const [freq, expectedName] of noteFreqs) {
+      const result = frequencyToNote(freq, 440);
+      expect(result.pitchName).toBe(expectedName);
+      expect(result.octaveNum).toBe(4);
+    }
+  });
+
+  it("シャープ/フラットを含む音名を変換する", () => {
+    // C#4 ≈ 277.18Hz
+    const cSharpFreq = 440 * Math.pow(2, -8 / 12);
+    const result = frequencyToNote(cSharpFreq, 440);
+    expect(result.pitchName).toBe("C#");
+    expect(result.octaveNum).toBe(4);
+  });
+});
+
+describe("detectPitch", () => {
+  const SAMPLE_RATE = 44100;
+  const BUFFER_SIZE = 4096;
+
+  it("440Hzの正弦波からAを検出する", () => {
+    const buffer = generateSineWave(440, SAMPLE_RATE, BUFFER_SIZE);
+    const candidates = detectPitch(buffer, SAMPLE_RATE, 440);
+
+    expect(candidates.length).toBeGreaterThan(0);
+    // 自己相関法は純粋な正弦波で倍音/基音のオクターブが揺れうるが、
+    // 音名はAとして検出されること
+    expect(candidates[0].pitchName).toBe("A");
+    expect(candidates[0].confidence).toBeGreaterThan(0.5);
+  });
+
+  it("無音のバッファでは空配列を返す", () => {
+    const buffer = new Float32Array(BUFFER_SIZE).fill(0);
+    const candidates = detectPitch(buffer, SAMPLE_RATE);
+
+    expect(candidates).toEqual([]);
+  });
+
+  it("非常に小さい振幅では検出しない", () => {
+    const buffer = generateSineWave(440, SAMPLE_RATE, BUFFER_SIZE, 0.001);
+    const candidates = detectPitch(buffer, SAMPLE_RATE);
+
+    expect(candidates).toEqual([]);
+  });
+
+  it("候補は最大3件まで返す", () => {
+    const buffer = generateSineWave(440, SAMPLE_RATE, BUFFER_SIZE);
+    const candidates = detectPitch(buffer, SAMPLE_RATE, 440);
+
+    expect(candidates.length).toBeLessThanOrEqual(3);
+  });
+
+  it("候補は信頼度の降順でソートされている", () => {
+    const buffer = generateSineWave(440, SAMPLE_RATE, BUFFER_SIZE);
+    const candidates = detectPitch(buffer, SAMPLE_RATE, 440);
+
+    for (let i = 1; i < candidates.length; i++) {
+      expect(candidates[i - 1].confidence).toBeGreaterThanOrEqual(
+        candidates[i].confidence
+      );
+    }
+  });
+
+  it("各候補のオクターブ番号は1〜6の範囲", () => {
+    const buffer = generateSineWave(440, SAMPLE_RATE, BUFFER_SIZE);
+    const candidates = detectPitch(buffer, SAMPLE_RATE, 440);
+
+    for (const c of candidates) {
+      expect(c.octaveNum).toBeGreaterThanOrEqual(1);
+      expect(c.octaveNum).toBeLessThanOrEqual(6);
+    }
+  });
+
+  it("異なる周波数でも正しく検出する（C4 ≈ 262Hz）", () => {
+    const c4Freq = 440 * Math.pow(2, -9 / 12);
+    const buffer = generateSineWave(c4Freq, SAMPLE_RATE, BUFFER_SIZE);
+    const candidates = detectPitch(buffer, SAMPLE_RATE, 440);
+
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates[0].pitchName).toBe("C");
+  });
+});
+
+describe("aggregatePitchResults", () => {
+  it("単一フレームの結果をそのまま返す", () => {
+    const frameResults: PitchCandidate[][] = [
+      [
+        { pitchName: "A", octaveNum: 4, frequency: 440, confidence: 0.9 },
+      ],
+    ];
+
+    const result = aggregatePitchResults(frameResults);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].pitchName).toBe("A");
+    expect(result[0].octaveNum).toBe(4);
+  });
+
+  it("複数フレームで同じ音が多いほど高スコアになる", () => {
+    const frameResults: PitchCandidate[][] = [
+      [
+        { pitchName: "A", octaveNum: 4, frequency: 440, confidence: 0.8 },
+        { pitchName: "A", octaveNum: 5, frequency: 880, confidence: 0.2 },
+      ],
+      [
+        { pitchName: "A", octaveNum: 4, frequency: 440, confidence: 0.9 },
+        { pitchName: "A", octaveNum: 5, frequency: 880, confidence: 0.1 },
+      ],
+      [
+        { pitchName: "A", octaveNum: 4, frequency: 440, confidence: 0.85 },
+      ],
+    ];
+
+    const result = aggregatePitchResults(frameResults);
+
+    expect(result[0].pitchName).toBe("A");
+    expect(result[0].octaveNum).toBe(4);
+  });
+
+  it("空のフレーム結果では空配列を返す", () => {
+    const result = aggregatePitchResults([]);
+    expect(result).toEqual([]);
+  });
+
+  it("全フレームが空の場合も空配列を返す", () => {
+    const result = aggregatePitchResults([[], [], []]);
+    expect(result).toEqual([]);
+  });
+
+  it("最大3件の結果を返す", () => {
+    const frameResults: PitchCandidate[][] = [
+      [
+        { pitchName: "A", octaveNum: 4, frequency: 440, confidence: 0.9 },
+        { pitchName: "B", octaveNum: 4, frequency: 494, confidence: 0.5 },
+        { pitchName: "C", octaveNum: 4, frequency: 262, confidence: 0.3 },
+        { pitchName: "D", octaveNum: 4, frequency: 294, confidence: 0.1 },
+      ],
+    ];
+
+    const result = aggregatePitchResults(frameResults);
+    expect(result.length).toBeLessThanOrEqual(3);
+  });
+
+  it("信頼度が合計100%に正規化される", () => {
+    const frameResults: PitchCandidate[][] = [
+      [
+        { pitchName: "A", octaveNum: 4, frequency: 440, confidence: 0.9 },
+        { pitchName: "B", octaveNum: 4, frequency: 494, confidence: 0.5 },
+      ],
+    ];
+
+    const result = aggregatePitchResults(frameResults);
+    const totalConfidence = result.reduce((sum, c) => sum + c.confidence, 0);
+
+    expect(totalConfidence).toBeCloseTo(1.0, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- `evaluateSpectrum()`（コアDSPアルゴリズム）のユニットテスト14件を追加
  - 基本動作（deviation計算、複数音同時評価、値の範囲）
  - セント偏差の方向性（シャープ/フラット）
  - 閾値処理（無音・微弱信号）
  - エッジケース（根音なし、enabled=false、空リスト、evalRangeCents=0）
  - デバッグ情報の出力制御
  - 異なるA4基準周波数
- `pitchDetection.ts` のユニットテスト20件を追加
  - `frequencyToNote`: 各音名変換、オクターブ、シャープ/フラット、カスタムA4
  - `detectPitch`: 正弦波検出、無音・微弱信号、候補数・ソート順・オクターブ範囲
  - `aggregatePitchResults`: フレーム集約、空入力、上限3件、信頼度正規化

## Motivation
テストカバレッジ調査の結果、アプリの中核である `evaluateSpectrum` と `pitchDetection` にテストがないことが判明。これらは純粋関数でテストしやすく、費用対効果が高い。

**テスト数: 95 → 129（+34）、スイート数: 14 → 16（+2）**

## Test plan
- [x] `npx jest --verbose` で全129テストがパスすることを確認済み

🤖 Generated with [Claude Code](https://claude.ai/claude-code)