### PR TITLE
feat: 音声ファイルの60fpsオフライン解析CLIを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,46 @@ npm test            # Jestテスト実行
 npm run test:watch  # Jestウォッチモード
 ```
 
+### 音声ファイル解析 CLI (Audio File Analysis CLI)
+
+マイク入力に加えて、録音済みの音声ファイル (wav / m4a / mp4 など ffmpeg が扱える形式) を
+60fps でフレーム解析し、既存のログ形式と同じ CSV にエクスポートできます。
+ブラウザの `AnalyserNode` と同等の挙動 (Blackman 窓・`smoothingTimeConstant` による
+指数平滑化・dB 変換) をエミュレートしており、`lib/audio_analysis/justAnalyze.ts` の
+`evaluateSpectrum()` をそのまま利用しています。
+
+構成音は **ファイル名末尾** で指定し、**先頭の音がルート** に固定されます。
+(`_` で区切られた最後のブロックを `-` で分割して音名 + オクターブ番号として解釈)
+
+```bash
+# 基本: 同ディレクトリに <入力名>.csv を出力
+npm run analyze:file -- path/to/song_C4-E4-G4.wav
+
+# 出力先を指定
+npm run analyze:file -- path/to/Cmaj7_C4-E4-G4-B4.m4a ./out.csv
+
+# サンプルレートを指定 (既定: 48000)
+npm run analyze:file -- path/to/F#4-A4-C#5.wav --sample-rate 44100
+```
+
+ファイル名の例:
+
+| 入力ファイル名 | 解釈される構成音 (先頭がルート) |
+| :-- | :-- |
+| `song_C4-E4-G4.wav` | C4 (root), E4, G4 |
+| `Cmaj7_C4-E4-G4-B4.m4a` | C4 (root), E4, G4, B4 |
+| `F#4-A4-C#5.wav` | F#4 (root), A4, C#5 |
+
+出力 CSV の列は実験モードのログと同一 (`timestamp`, `elapsedMs`, `sessionId`,
+`pitchName`, `pitchIsRoot`, `deviation`, `centDeviation`, `centDeviationRaw`,
+`centDeviationDisplay`, `isDetected`, `isHeld`, `a4Freq`, `evalRangeCents`,
+`evalThreshold`, `fftSize`, `smoothingTimeConstant`) で、60fps で 1 フレームにつき
+構成音ごとに 1 行ずつ書き出します。解析パラメータ (A4 周波数・FFT サイズ・評価範囲・
+閾値・スムージング定数) は `lib/constants.ts` のブラウザ側デフォルトを使用します。
+
+> ffmpeg バイナリは `ffmpeg-static` (devDependency) から自動で解決されるため、
+> 別途のインストールは不要です。
+
 ## 使い方 (Usage)
 
 ### 基本的な使用方法

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,12 +47,15 @@
         "baseline-browser-mapping": "^2.9.13",
         "eslint": "^9",
         "eslint-config-next": "15.3.2",
+        "ffmpeg-static": "^5.3.0",
+        "fft.js": "^4.0.4",
         "jest": "^30.0.2",
         "jest-environment-jsdom": "^30.0.2",
         "sharp": "^0.34.4",
         "tailwindcss": "^4",
         "ts-jest": "^29.4.0",
         "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
         "tw-animate-css": "^1.3.4",
         "typescript": "^5"
       }
@@ -1943,6 +1946,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -7031,6 +7050,13 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7265,6 +7291,22 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -7756,6 +7798,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -8183,6 +8235,19 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -8191,6 +8256,29 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -8568,6 +8656,57 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fft.js": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/fft.js/-/fft.js-4.0.4.tgz",
+      "integrity": "sha512-f9c00hphOgeQTlDyavwTtu6RiK8AIFjD6+jvXkNkpeQ7rirK3uFWVpalkoS4LAwbdX7mfZ8aoBfFVQX1Re/8aw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -9224,6 +9363,23 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -12128,6 +12284,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -12444,6 +12606,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -12630,6 +12802,21 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/redent": {
@@ -13393,6 +13580,16 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -14253,29 +14450,18 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
+        "json5": "^2.2.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
       },
-      "bin": {
-        "json5": "lib/cli.js"
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tsconfig-paths/node_modules/strip-bom": {
@@ -14413,6 +14599,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -14653,6 +14846,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "analyze:file": "ts-node --project scripts/tsconfig.json scripts/analyze-audio-file.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
@@ -50,12 +51,15 @@
     "baseline-browser-mapping": "^2.9.13",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
+    "ffmpeg-static": "^5.3.0",
+    "fft.js": "^4.0.4",
     "jest": "^30.0.2",
     "jest-environment-jsdom": "^30.0.2",
     "sharp": "^0.34.4",
     "tailwindcss": "^4",
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "tw-animate-css": "^1.3.4",
     "typescript": "^5"
   }

--- a/scripts/analyze-audio-file.ts
+++ b/scripts/analyze-audio-file.ts
@@ -1,0 +1,428 @@
+/**
+ * analyze-audio-file
+ *
+ * 音声ファイル (wav / m4a / mp4 など ffmpeg が扱える形式) を 60fps でフレーム解析し、
+ * 既存の evaluateSpectrum() と同じロジックで構成音ごとの偏差を計算して CSV に書き出す。
+ *
+ * Web Audio API (AnalyserNode) の挙動を模倣するため、以下を実装している:
+ *  - Blackman 窓 (W3C 仕様: w[n] = 0.42 - 0.5*cos(2πn/N) + 0.08*cos(4πn/N))
+ *  - 実数 FFT -> 複素スペクトル -> 振幅 / fftSize
+ *  - 前フレーム振幅とのスムージング: X̂[k] = τ * X̂_prev[k] + (1 - τ) * |X[k]|
+ *  - dB 変換: 20 * log10(X̂[k])
+ *
+ * 構成音は入力ファイル名から抽出する。先頭の音がルート (isRoot) で固定。
+ *   例) "song_C4-E4-G4.wav" → [C4(root), E4, G4]
+ *   例) "C4-E4-G4.m4a"     → [C4(root), E4, G4]
+ *
+ * 使い方:
+ *   npm run analyze:file -- <audio-file> [output.csv]
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+
+import FFT from "fft.js";
+import ffmpegPath from "ffmpeg-static";
+
+import { evaluateSpectrum } from "@/lib/audio_analysis/justAnalyze";
+import {
+  A4_FREQ,
+  FFT_SIZE,
+  SMOOTHING_TIME_CONSTANT,
+  EVAL_RANGE_CENTS,
+  EVAL_THRESHOLD,
+  PITCH_NAME_LIST,
+  OCTAVE_NUM_LIST,
+} from "@/lib/constants";
+import type { Pitch } from "@/lib/types";
+
+const FPS = 60;
+const DEFAULT_SAMPLE_RATE = 48000;
+
+interface ParsedArgs {
+  inputPath: string;
+  outputPath: string;
+  sampleRate: number;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const args = argv.slice(2);
+  if (args.length === 0 || args.includes("-h") || args.includes("--help")) {
+    printUsage();
+    process.exit(args.length === 0 ? 1 : 0);
+  }
+
+  let sampleRate = DEFAULT_SAMPLE_RATE;
+  const positional: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--sample-rate" || a === "-r") {
+      const next = args[++i];
+      if (!next) throw new Error("--sample-rate requires a value");
+      sampleRate = parseInt(next, 10);
+      if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
+        throw new Error(`Invalid sample rate: ${next}`);
+      }
+    } else {
+      positional.push(a);
+    }
+  }
+
+  if (positional.length === 0) {
+    throw new Error("Input audio file path is required");
+  }
+
+  const inputPath = positional[0];
+  const outputPath =
+    positional[1] ??
+    inputPath.replace(/\.[^.]+$/, "") + ".csv";
+
+  return { inputPath, outputPath, sampleRate };
+}
+
+function printUsage(): void {
+  console.log(
+    [
+      "Usage: npm run analyze:file -- <audio-file> [output.csv] [--sample-rate <hz>]",
+      "",
+      "Arguments:",
+      "  <audio-file>   Path to wav/m4a/mp4/etc. File name must contain the",
+      "                 constituent pitches as the last underscore-delimited block,",
+      "                 with pitches separated by '-'. First pitch is treated as root.",
+      "                 Examples:",
+      "                   song_C4-E4-G4.wav      -> [C4 (root), E4, G4]",
+      "                   Cmaj7_C4-E4-G4-B4.m4a  -> [C4 (root), E4, G4, B4]",
+      "                   F#4-A4-C#5.wav         -> [F#4 (root), A4, C#5]",
+      "  [output.csv]   Optional output path (default: alongside input, .csv ext).",
+      "",
+      "Options:",
+      `  --sample-rate  Sample rate used for decoding & analysis (default ${DEFAULT_SAMPLE_RATE}).`,
+    ].join("\n"),
+  );
+}
+
+/**
+ * ファイル名末尾の構成音ブロックを解釈する。
+ * 例: "anything_C4-E4-G4.wav" -> ["C4", "E4", "G4"]
+ * 例: "C4-E4-G4.wav"          -> ["C4", "E4", "G4"]
+ */
+function parsePitchesFromFilename(filePath: string): Pitch[] {
+  const base = path.basename(filePath, path.extname(filePath));
+  const segments = base.split("_");
+  const pitchSegment = segments[segments.length - 1];
+  const tokens = pitchSegment.split("-").filter((t) => t.length > 0);
+
+  if (tokens.length === 0) {
+    throw new Error(`Could not extract pitches from filename "${base}"`);
+  }
+
+  const pitches: Pitch[] = tokens.map((token, i) => {
+    const match = token.match(/^([A-G](?:#|b)?)(\d)$/);
+    if (!match) {
+      throw new Error(
+        `Invalid pitch token "${token}" in filename. Expected like "C4", "F#3", "Bb5".`,
+      );
+    }
+    const [, pitchName, octaveStr] = match;
+    const octaveNum = parseInt(octaveStr, 10);
+    if (!PITCH_NAME_LIST.includes(pitchName)) {
+      throw new Error(
+        `Unsupported pitch name "${pitchName}". Allowed: ${PITCH_NAME_LIST.join(", ")}`,
+      );
+    }
+    if (!OCTAVE_NUM_LIST.includes(octaveNum)) {
+      throw new Error(
+        `Unsupported octave "${octaveNum}". Allowed: ${OCTAVE_NUM_LIST.join(", ")}`,
+      );
+    }
+    return {
+      pitchName: pitchName as Pitch["pitchName"],
+      octaveNum,
+      isRoot: i === 0,
+      enabled: true,
+    };
+  });
+
+  return pitches;
+}
+
+/**
+ * ffmpeg で任意の音声ファイルをモノラル 32bit float little-endian PCM にデコードして返す。
+ */
+function decodeAudioToMonoFloat32(audioPath: string, sampleRate: number): Float32Array {
+  if (!ffmpegPath) {
+    throw new Error("ffmpeg-static binary path is not available on this platform");
+  }
+  if (!fs.existsSync(audioPath)) {
+    throw new Error(`Audio file not found: ${audioPath}`);
+  }
+
+  const result = spawnSync(
+    ffmpegPath,
+    [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-i",
+      audioPath,
+      "-f",
+      "f32le",
+      "-ac",
+      "1",
+      "-ar",
+      String(sampleRate),
+      "-",
+    ],
+    { maxBuffer: 1024 * 1024 * 1024 },
+  );
+
+  if (result.status !== 0) {
+    const err = result.stderr?.toString() ?? "(no stderr)";
+    throw new Error(`ffmpeg decode failed (status=${result.status}): ${err}`);
+  }
+
+  const stdout = result.stdout as Buffer;
+  if (stdout.length === 0) {
+    throw new Error("ffmpeg produced empty PCM output");
+  }
+  if (stdout.length % 4 !== 0) {
+    throw new Error(
+      `PCM stream length (${stdout.length}) is not a multiple of 4 bytes (f32)`,
+    );
+  }
+
+  const samples = new Float32Array(stdout.length / 4);
+  for (let i = 0; i < samples.length; i++) {
+    samples[i] = stdout.readFloatLE(i * 4);
+  }
+  return samples;
+}
+
+/**
+ * Web Audio API 仕様の Blackman 窓
+ *   w[n] = 0.42 - 0.5 * cos(2π * n / N) + 0.08 * cos(4π * n / N), 0 ≤ n < N
+ */
+function buildBlackmanWindow(size: number): Float32Array {
+  const w = new Float32Array(size);
+  const twoPiOverN = (2 * Math.PI) / size;
+  const fourPiOverN = (4 * Math.PI) / size;
+  for (let n = 0; n < size; n++) {
+    w[n] =
+      0.42 - 0.5 * Math.cos(twoPiOverN * n) + 0.08 * Math.cos(fourPiOverN * n);
+  }
+  return w;
+}
+
+/**
+ * AnalyserNode.getFloatFrequencyData() を模倣するクラス。
+ * 呼び出すたびに「現在時刻から過去 fftSize サンプル分」を受け取り、
+ *   - Blackman 窓
+ *   - 実数 FFT
+ *   - 振幅 / fftSize
+ *   - 前フレームとのスムージング (smoothingTimeConstant)
+ *   - dB 変換
+ * を行い、長さ fftSize/2 の dB スペクトルを返す。
+ */
+class AnalyserEmulator {
+  private readonly fft: FFT;
+  private readonly fftSize: number;
+  private readonly smoothing: number;
+  private readonly window: Float32Array;
+  private readonly smoothedMagnitude: Float64Array;
+  private readonly windowed: Float64Array;
+  private readonly complexOut: Float64Array;
+
+  constructor(fftSize: number, smoothing: number) {
+    this.fftSize = fftSize;
+    this.smoothing = smoothing;
+    this.fft = new FFT(fftSize);
+    this.window = buildBlackmanWindow(fftSize);
+    this.smoothedMagnitude = new Float64Array(fftSize / 2);
+    this.windowed = new Float64Array(fftSize);
+    // fft.js complex array length = 2 * size
+    this.complexOut = new Float64Array(fftSize * 2);
+  }
+
+  /**
+   * fftSize サンプル分の時間領域信号を受け取り dB スペクトル (長さ fftSize/2) を返す。
+   */
+  analyze(samples: Float32Array): Float32Array {
+    if (samples.length !== this.fftSize) {
+      throw new Error(
+        `analyze(): expected ${this.fftSize} samples, got ${samples.length}`,
+      );
+    }
+
+    for (let i = 0; i < this.fftSize; i++) {
+      this.windowed[i] = samples[i] * this.window[i];
+    }
+
+    this.fft.realTransform(
+      this.complexOut as unknown as number[],
+      this.windowed as unknown as number[],
+    );
+    this.fft.completeSpectrum(this.complexOut as unknown as number[]);
+
+    const half = this.fftSize / 2;
+    const out = new Float32Array(half);
+    const invN = 1 / this.fftSize;
+    const tau = this.smoothing;
+    const oneMinusTau = 1 - tau;
+
+    for (let k = 0; k < half; k++) {
+      const re = this.complexOut[2 * k];
+      const im = this.complexOut[2 * k + 1];
+      const mag = Math.sqrt(re * re + im * im) * invN;
+
+      const smoothed = tau * this.smoothedMagnitude[k] + oneMinusTau * mag;
+      this.smoothedMagnitude[k] = smoothed;
+
+      out[k] = smoothed > 0 ? 20 * Math.log10(smoothed) : -Infinity;
+    }
+
+    return out;
+  }
+}
+
+function buildFrequencyBins(fftSize: number, sampleRate: number): number[] {
+  const half = fftSize / 2;
+  const step = sampleRate / fftSize;
+  const bins = new Array<number>(half);
+  for (let i = 0; i < half; i++) {
+    bins[i] = i * step;
+  }
+  return bins;
+}
+
+function escapeCsvValue(
+  value: string | number | boolean | null | undefined,
+): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : "";
+  }
+  if (typeof value === "boolean") return String(value);
+  const s = String(value);
+  if (s.includes(",") || s.includes("\n") || s.includes('"')) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+const CSV_HEADERS = [
+  "timestamp",
+  "elapsedMs",
+  "sessionId",
+  "pitchName",
+  "pitchIsRoot",
+  "deviation",
+  "centDeviation",
+  "centDeviationRaw",
+  "centDeviationDisplay",
+  "isDetected",
+  "isHeld",
+  "a4Freq",
+  "evalRangeCents",
+  "evalThreshold",
+  "fftSize",
+  "smoothingTimeConstant",
+];
+
+async function main(): Promise<void> {
+  const { inputPath, outputPath, sampleRate } = parseArgs(process.argv);
+
+  const pitchList = parsePitchesFromFilename(inputPath);
+  console.log(
+    `Input : ${inputPath}\n` +
+      `Output: ${outputPath}\n` +
+      `Pitches: ${pitchList
+        .map((p) => `${p.pitchName}${p.octaveNum}${p.isRoot ? " (root)" : ""}`)
+        .join(", ")}\n` +
+      `Sample rate: ${sampleRate} Hz, FFT size: ${FFT_SIZE}, FPS: ${FPS}`,
+  );
+
+  const audio = decodeAudioToMonoFloat32(inputPath, sampleRate);
+  const totalDurationSec = audio.length / sampleRate;
+  console.log(
+    `Decoded ${audio.length} samples (${totalDurationSec.toFixed(3)} s)`,
+  );
+
+  const freqBins = buildFrequencyBins(FFT_SIZE, sampleRate);
+  const analyser = new AnalyserEmulator(FFT_SIZE, SMOOTHING_TIME_CONSTANT);
+
+  const sessionId = randomUUID();
+  const sessionStartMs = Date.now();
+  const frameWindow = new Float32Array(FFT_SIZE);
+
+  const totalFrames = Math.max(0, Math.floor(totalDurationSec * FPS));
+  const csvRows: string[] = [CSV_HEADERS.join(",")];
+
+  for (let frame = 0; frame < totalFrames; frame++) {
+    const elapsedMs = (frame * 1000) / FPS;
+    const endSampleExclusive = Math.floor((elapsedMs * sampleRate) / 1000) + 1;
+    const startSample = endSampleExclusive - FFT_SIZE;
+
+    // AnalyserNode は「直近 fftSize サンプル」を使う。開始直後は無音で埋める。
+    for (let i = 0; i < FFT_SIZE; i++) {
+      const idx = startSample + i;
+      frameWindow[i] = idx >= 0 && idx < audio.length ? audio[idx] : 0;
+    }
+
+    const spectrum = analyser.analyze(frameWindow);
+    const results = evaluateSpectrum(
+      spectrum,
+      freqBins,
+      pitchList,
+      EVAL_RANGE_CENTS,
+      A4_FREQ,
+      EVAL_THRESHOLD,
+    );
+
+    const timestamp = new Date(sessionStartMs + elapsedMs).toISOString();
+
+    for (let i = 0; i < pitchList.length; i++) {
+      const pitch = pitchList[i];
+      const r = results[i];
+      const deviation = r?.deviation ?? null;
+      const centDeviation = r?.centDeviation ?? null;
+      const isDetected = deviation !== null;
+
+      const row = [
+        escapeCsvValue(timestamp),
+        escapeCsvValue(elapsedMs),
+        escapeCsvValue(sessionId),
+        escapeCsvValue(`${pitch.pitchName}${pitch.octaveNum}`),
+        escapeCsvValue(pitch.isRoot ?? false),
+        escapeCsvValue(deviation),
+        escapeCsvValue(centDeviation !== null ? Number(centDeviation) : null),
+        escapeCsvValue(centDeviation !== null ? Number(centDeviation) : null),
+        "",
+        escapeCsvValue(isDetected),
+        escapeCsvValue(false),
+        escapeCsvValue(A4_FREQ),
+        escapeCsvValue(EVAL_RANGE_CENTS),
+        escapeCsvValue(EVAL_THRESHOLD),
+        escapeCsvValue(FFT_SIZE),
+        escapeCsvValue(SMOOTHING_TIME_CONSTANT),
+      ];
+      csvRows.push(row.join(","));
+    }
+  }
+
+  const bom = "﻿";
+  fs.writeFileSync(outputPath, bom + csvRows.join("\n") + "\n", "utf8");
+  console.log(
+    `Wrote ${outputPath} (${totalFrames} frames × ${pitchList.length} pitches = ${
+      totalFrames * pitchList.length
+    } rows)`,
+  );
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`Error: ${msg}`);
+  process.exit(1);
+});

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES2020",
+    "noEmit": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "baseUrl": "..",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["./**/*.ts", "../lib/**/*.ts"],
+  "ts-node": {
+    "transpileOnly": true,
+    "require": ["tsconfig-paths/register"]
+  }
+}


### PR DESCRIPTION
wav/m4a/mp4 等を ffmpeg (ffmpeg-static) でデコードし、Web Audio API の
AnalyserNode と同等のスペクトル (Blackman 窓・smoothingTimeConstant による
平滑化・dB 変換) を fft.js でエミュレートして 60fps で解析する。既存の
evaluateSpectrum() をそのまま使用し、出力 CSV は実験モードのログ形式と列・
挙動を揃える。

構成音はファイル名末尾 (例: song_C4-E4-G4.wav) で指定し、先頭がルートに固定。
実行は npm run analyze:file -- <audio-file> [output.csv]。