### PR TITLE
fix: 針のCSSトランジションを削除しピーク表示と同期させる

### DIFF
--- a/components/feedback/MeterFeedback.tsx
+++ b/components/feedback/MeterFeedback.tsx
@@ -205,7 +205,6 @@ export const TunerMeter: React.FC<TunerMeterProps> = ({
                   style={{
                     transformOrigin: "50px 50px",
                     transform: `rotate(${needleRotation}deg)`,
-                    transition: "transform 0.2s ease-out",
                   }}
                 />
               );


### PR DESCRIPTION
実験モードで周波数ピーク表示は snap 描画なのに対し、針は
transform 0.2s ease-out で補間されていたため、針だけが入力
ピッチより遅れて追随しているように見える問題を修正。
両者を同じ snap 挙動に揃える。